### PR TITLE
Use shield icon for discord join

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+
 HotWired - Discord Bot
 =======================
 
-This bot is Custom made For the codin' Hole Discord server
+[![Discord](https://img.shields.io/static/v1?label=The%20Codin'%20Hole&logo=discord&message=%3E200%20members&color=%237289DA&logoColor=white)](https://discord.gg/vP26dCy)
 
-If you're interested in contributing in code, Join at [The Codin' Hole Discord Server](https://discord.gg/vP26dCy)
+This bot is Custom made For the codin' Hole Discord server


### PR DESCRIPTION
There can be an icon shield on top of the readme for joining to the discord server instead of using a link somewhere else